### PR TITLE
Implemented automatic crew transfer vote

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -101,6 +101,16 @@
 	integer = FALSE
 	min_val = 0
 
+/datum/config_entry/number/vote_autotransfer_initial //length of time before the first autotransfer vote is called (deciseconds, default 2 hours)
+	config_entry_value = 72000
+	integer = FALSE
+	min_val = 0
+
+/datum/config_entry/number/vote_autotransfer_interval //length of time to wait before subsequent autotransfer votes (deciseconds, default 30 minutes)
+	config_entry_value = 18000
+	integer = FALSE
+	min_val = 0
+
 /datum/config_entry/flag/default_no_vote	// vote does not default to nochange/norestart
 
 /datum/config_entry/flag/no_dead_vote	// dead people can't vote

--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -1,0 +1,17 @@
+SUBSYSTEM_DEF(autotransfer)
+	name = "Autotransfer Vote"
+	flags = SS_KEEP_TIMING | SS_BACKGROUND
+	wait = 1 MINUTES
+
+	var/starttime
+	var/targettime
+
+/datum/controller/subsystem/autotransfer/Initialize(timeofday)
+	starttime = world.time
+	targettime = starttime + CONFIG_GET(number/vote_autotransfer_initial)
+
+/datum/controller/subsystem/autotransfer/fire()
+	if (world.time > targettime)
+		SSvote.initiate_vote("transfer",null) //TODO figure out how to not use null as the user
+		targettime = targettime + CONFIG_GET(number/vote_autotransfer_interval)
+

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -71,6 +71,21 @@ SUBSYSTEM_DEF(vote)
 					choices[GLOB.master_mode] += non_voters.len
 					if(choices[GLOB.master_mode] >= greatest_votes)
 						greatest_votes = choices[GLOB.master_mode]
+			else if(mode == "transfer")
+				var/factor = 1
+				switch(world.time / (1 MINUTES ))
+					if(0 to 60)
+						factor = 0.5
+					if(61 to 120)
+						factor = 0.8
+					if(121 to 240)
+						factor = 1
+					if(241 to 300)
+						factor = 1.2
+					else
+						factor = 1.4
+				choices["Initiate Crew Transfer"] += round(non_voters.len * factor)
+
 	//get all options with that many votes and return them in a list
 	. = list()
 	if(greatest_votes)
@@ -123,6 +138,12 @@ SUBSYSTEM_DEF(vote)
 						restart = 1
 					else
 						GLOB.master_mode = .
+			if("transfer")
+				//TODO find a cleaner way to do this
+				SSshuttle.requestEvac(null,"Crew transfer requested.")
+				var/obj/machinery/computer/communications/C = locate() in GLOB.machines
+				if(C)
+					C.post_status("shuttle")
 	if(restart)
 		var/active_admins = 0
 		for(var/client/C in GLOB.admins)
@@ -165,12 +186,15 @@ SUBSYSTEM_DEF(vote)
 				to_chat(usr, "<span class='warning'>A vote was initiated recently, you must wait [DisplayTimeText(next_allowed_time-world.time)] before a new vote can be started!</span>")
 				return 0
 
+		SEND_SOUND(world, sound('sound/misc/notice2.ogg'))
 		reset()
 		switch(vote_type)
 			if("restart")
 				choices.Add("Restart Round","Continue Playing")
 			if("gamemode")
 				choices.Add(config.votable_modes)
+			if("transfer")
+				choices.Add("Initiate Crew Transfer","Continue Playing")
 			if("custom")
 				question = stripped_input(usr,"What is the vote for?")
 				if(!question)
@@ -183,7 +207,7 @@ SUBSYSTEM_DEF(vote)
 			else
 				return 0
 		mode = vote_type
-		initiator = initiator_key
+		initiator = initiator_key ? initiator_key : "the Server"
 		started_time = world.time
 		var/text = "[capitalize(mode)] vote started by [initiator]."
 		if(mode == "custom")

--- a/config/config.txt
+++ b/config/config.txt
@@ -173,6 +173,12 @@ VOTE_DELAY 3000
 ## time period (deciseconds) which voting session will last (default 1 minute)
 VOTE_PERIOD 1200
 
+## autovote initial delay (deciseconds) before first automatic transfer vote call (default 120 minutes)
+VOTE_AUTOTRANSFER_INITIAL 72000
+
+##autovote delay (deciseconds) before sequential automatic transfer votes are called (default 30 minutes)
+VOTE_AUTOTRANSFER_INTERVAL 18000
+
 ## prevents dead players from voting or starting votes
 # NO_DEAD_VOTE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -218,6 +218,7 @@
 #include "code\controllers\subsystem\assets.dm"
 #include "code\controllers\subsystem\atoms.dm"
 #include "code\controllers\subsystem\augury.dm"
+#include "code\controllers\subsystem\autotransfer.dm"
 #include "code\controllers\subsystem\blackbox.dm"
 #include "code\controllers\subsystem\communications.dm"
 #include "code\controllers\subsystem\dbcore.dm"


### PR DESCRIPTION

## About The Pull Request

Added the automatic crew transfer vote, which when passed calls the shuttle to end the round softly if the round duration is too high.

The initial time for the first vote, as well as the interval between subsequent votes can both be set via the config vars `VOTE_AUTOTRANSFER_INITIAL` and `VOTE_AUTOTRANSFER_INTERVAL`. 

By default the first vote will occur at 2 hours, and if that vote fails subsequent votes will occur every 30 minutes.

Other minor changes include all votes now make a sound when they start, and votes that're started without a user will be listed as being started "by the server" to avoid "Vote started by ."
## Changelog
:cl:
add: crew transfer vote type, when successful calls the emergency shuttle 
add: vote_autotransfer_initial config setting for time before first vote
add: vote_autotransfer_interval config setting for time between subsequent votes
add: votes now play a sound when initiated
tweak: votes initiated with no user will be described as started by server
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
