### PR TITLE
Autotransfer vote now actually checks the vote result

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -139,11 +139,12 @@ SUBSYSTEM_DEF(vote)
 					else
 						GLOB.master_mode = .
 			if("transfer")
-				//TODO find a cleaner way to do this
-				SSshuttle.requestEvac(null,"Crew transfer requested.")
-				var/obj/machinery/computer/communications/C = locate() in GLOB.machines
-				if(C)
-					C.post_status("shuttle")
+				if(. == "Initiate Crew Transfer")
+					//TODO find a cleaner way to do this
+					SSshuttle.requestEvac(null,"Crew transfer requested.")
+					var/obj/machinery/computer/communications/C = locate() in GLOB.machines
+					if(C)
+						C.post_status("shuttle")
 	if(restart)
 		var/active_admins = 0
 		for(var/client/C in GLOB.admins)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Basically I'm an idiot and didn't check whether initial crew transfer was actually the chosen option and just called the shuttle always. This patch fixes that
## Changelog
:cl:
fix: Crew transfer vote now actually based on vote result
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
