### PR TITLE
Automatic switching to and from sandbox depending on population.

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -382,3 +382,15 @@
 /datum/config_entry/number/monkeycap
 	config_entry_value = 64
 	min_val = 0
+
+/datum/config_entry/flag/autosandbox_enabled //whether or not autosandbox is enabled.
+
+/datum/config_entry/number/autosandbox_min //the threshold at which the server will drop to sandbox (default: 5 players)
+	config_entry_value = 5
+	min_val = 0
+	integer = TRUE
+
+/datum/config_entry/number/autosandbox_max //the threshold at which the server will swap to secret (default: 10 players)
+	config_entry_value = 10
+	min_val = 0
+	integer = TRUE

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -31,6 +31,8 @@ SUBSYSTEM_DEF(ticker)
 	var/tipped = 0							//Did we broadcast the tip of the day yet?
 	var/selected_tip						// What will be the tip of the day?
 
+	var/autosandbox_checked = FALSE
+
 	var/timeLeft						//pregame timer
 	var/start_at
 
@@ -161,6 +163,43 @@ SUBSYSTEM_DEF(ticker)
 			if(timeLeft <= 300 && !tipped)
 				send_tip_of_the_round()
 				tipped = TRUE
+
+			//perform autosandbox check
+			if(timeLeft <= 100 && !autosandbox_checked)
+				autosandbox_checked = TRUE
+
+				if(CONFIG_GET(flag/autosandbox_enabled))
+
+					//check for present admins
+					var/active_admins = 0
+					for(var/client/C in GLOB.admins)
+						if(!C.is_afk() && check_rights_for(C, R_ADMIN))
+							active_admins = 1
+							break
+
+					//shift down to sandbox
+					if(GLOB.master_mode == "secret" && totalPlayers <= CONFIG_GET(number/autosandbox_min))
+						SEND_SOUND(world, sound('sound/misc/notice2.ogg'))
+						if(!active_admins)
+							to_chat(world, "<span class='boldnotice'>Notice: Insufficient player population for secret, switching from secret to sandbox.</span>")
+							SSticker.save_mode("sandbox")
+							GLOB.master_mode = "sandbox"
+						else
+							to_chat(world, "<span class='boldnotice'>Notice: The current player count is below the sandbox threshold, but the game mode will not be changed because an admin is online.</span>")
+							message_admins("The player count is below the auto sandbox population threshold, but there are active admins, so the game mode has not changed. If you wish, you may change the game mode to sandbox.")
+
+					//shift up to secret
+					else if(GLOB.master_mode == "sandbox" && totalPlayers >= CONFIG_GET(number/autosandbox_max))
+						SEND_SOUND(world, sound('sound/misc/notice2.ogg'))
+						if(!active_admins)
+							to_chat(world, "<span class='boldnotice'>Notice: Player population is now sufficient for secret, switching from sandbox to secret.</span>")
+							SSticker.save_mode("secret")
+							GLOB.master_mode = "secret"
+						else
+							to_chat(world, "<span class='boldnotice'>Notice: The current player count is meets the secret threshold, but the game mode will not be changed because an admin is online.</span>")
+							message_admins("The player count meets the auto secret population threshold, but there are active admins, so the game mode has not changed. If you wish, you may change the game mode to secret.")
+
+
 
 			if(timeLeft <= 0)
 				current_state = GAME_STATE_SETTING_UP
@@ -410,7 +449,7 @@ SUBSYSTEM_DEF(ticker)
 		queued_players.len = 0
 		queue_delay = 0
 		return
-		
+
 	queue_delay++
 	var/mob/dead/new_player/next_in_line = queued_players[1]
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -202,6 +202,16 @@ MIN_POP CLOCKWORK_CULT 15
 #MIN_POP EXTENDED 0
 #MAX_POP EXTENDED -1
 
+## Uncomment to enable automatic switching to sandbox when player count falls below a threshold 
+AUTOSANDBOX_ENABLED
+
+## The threshold at which the server will automatically swap from secret to sandbox if server population is less than or equal to this number (default: 5)
+AUTOSANDBOX_MIN 5
+
+## The threshold at which the server will automatically swap from sandbox to secret if server population is greater than or equal to this number (default: 10)
+AUTOSANDBOX_MAX 10
+
+
 
 
 ## The amount of time it takes for the emergency shuttle to be called, from round start.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a setting for the server to be capable of automatically changing the game mode between sandbox and secret based on player population without the need for admin input. The thresholds at which the server will drop to sandbox and return to secret can set in the game options config, as well as entirely enabling or disabling the system via the `autosandbox_enabled` flag. 

The check for whether to change game modes happens 10 seconds before round start to ensure the highest likelihood that all players intending to join the round have arrived. If any admins are active on the server the system will make no changes to the game mode.

## Why It's Good For The Game

Because the population of the server fluctuates highly depending on the time, its constantly required of admins to log on and change the game mode back and forth between sandbox and secret. This PR alleviates the issue by having the server be able to perform this task automatically.

## Changelog
:cl:
add: Added the ability for the server to change between sandbox and secret on its own.
config: Added configuration options for autosandbox thresholds and an enabled flag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
