### PR TITLE
Added fix_air admin verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -17,7 +17,8 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/reestablish_db_connection, /*reattempt a connection to the database*/
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
 	/client/proc/cmd_admin_pm_panel,		/*admin-pm list*/
-	/client/proc/stop_sounds
+	/client/proc/stop_sounds,
+	/client/proc/fix_air // fix air verb, ported from yog
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 GLOBAL_PROTECT(admin_verbs_admin)

--- a/code/modules/admin/verbs/fix_air.dm
+++ b/code/modules/admin/verbs/fix_air.dm
@@ -1,0 +1,21 @@
+// Proc taken from yogstation, credit to nichlas0010 for the original
+/client/proc/fix_air(var/turf/open/T in world)
+	set name = "Fix Air"
+	set category = "Admin"
+	set desc = "Fixes air in specified radius."
+
+	if(!holder)
+		to_chat(src, "Only administrators may use this command.")
+		return
+	if(check_rights(R_ADMIN,1))
+		var/range=input("Enter range:","Num",2) as num
+		message_admins("[key_name_admin(usr)] fixed air with range [range] in area [T.loc.name]")
+		log_game("[key_name_admin(usr)] fixed air with range [range] in area [T.loc.name]")
+		var/datum/gas_mixture/GM = new
+		for(var/turf/open/F in range(range,T))
+			if(F.blocks_air)
+			//skip walls
+				continue
+			GM.parse_gas_string(F.initial_gas_mix)
+			F.copy_air(GM)
+			F.update_visuals()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1144,6 +1144,7 @@
 #include "code\modules\admin\verbs\deadsay.dm"
 #include "code\modules\admin\verbs\debug.dm"
 #include "code\modules\admin\verbs\diagnostics.dm"
+#include "code\modules\admin\verbs\fix_air.dm"
 #include "code\modules\admin\verbs\fps.dm"
 #include "code\modules\admin\verbs\getlogs.dm"
 #include "code\modules\admin\verbs\individual_logging.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does exactly what it says on the tin, ports the fix_air verb from yogstation.

## Why It's Good For The Game

Self explanatory.

## Changelog
:cl:
admin: Admins now have the fix air verb.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
