### PR TITLE
Nyctophobia move intent tweak

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -256,6 +256,7 @@
 	name = "Nyctophobia"
 	desc = "As far as you can remember, you've always been afraid of the dark. While in the dark without a light source, you instinctually act careful, and constantly feel a sense of dread."
 	value = -1
+	var/careful = FALSE
 
 /datum/quirk/nyctophobia/on_process()
 	var/mob/living/carbon/human/H = quirk_holder
@@ -267,8 +268,15 @@
 		if(quirk_holder.m_intent == MOVE_INTENT_RUN)
 			to_chat(quirk_holder, "<span class='warning'>Easy, easy, take it slow... you're in the dark...</span>")
 			quirk_holder.toggle_move_intent()
+			careful = TRUE 
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "nyctophobia", /datum/mood_event/nyctophobia)
-	else
+	else if(careful)
+		to_chat(quirk_holder, "<span class='warning'>You can see again! Praise the sun!</span>")
+		if(quirk_holder.m_intent == MOVE_INTENT_WALK)
+			quirk_holder.toggle_move_intent()
+		careful = FALSE
+		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "nyctophobia")
+	else 
 		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "nyctophobia")
 
 /datum/quirk/nonviolent

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -270,14 +270,14 @@
 			quirk_holder.toggle_move_intent()
 			careful = TRUE 
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "nyctophobia", /datum/mood_event/nyctophobia)
-	else if(careful)
-		to_chat(quirk_holder, "<span class='warning'>You can see again! Praise the sun!</span>")
-		if(quirk_holder.m_intent == MOVE_INTENT_WALK)
-			quirk_holder.toggle_move_intent()
-		careful = FALSE
-		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "nyctophobia")
 	else 
+		if(careful)
+			to_chat(quirk_holder, "<span class='warning'>You can see again! Praise the sun!</span>")
+			if(quirk_holder.m_intent == MOVE_INTENT_WALK)
+				quirk_holder.toggle_move_intent()
+			careful = FALSE
 		SEND_SIGNAL(quirk_holder, COMSIG_CLEAR_MOOD_EVENT, "nyctophobia")
+
 
 /datum/quirk/nonviolent
 	name = "Pacifist"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes nyctophobia quirk so it you are automatically set to running move intent after it is set to walk from being in the dark.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It saves a keystroke every time you go into the dark with the quirk. Convenience!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Nyctophobia sets your move intent back to run after being in the dark.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
