### PR TITLE
Autosandbox will now enable respawn

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -183,7 +183,7 @@ SUBSYSTEM_DEF(ticker)
 					if(GLOB.master_mode == "secret" && totalPlayers <= CONFIG_GET(number/autosandbox_min))
 						SEND_SOUND(world, sound('sound/misc/notice2.ogg'))
 						if(!active_admins)
-							to_chat(world, "<span class='boldnotice'>Notice: Insufficient player population for secret, switching from secret to sandbox.</span>")
+							to_chat(world, "<span class='boldnotice'>Notice: Insufficient player population for secret, switching from secret to sandbox and enabling respawn.</span>")
 							SSticker.save_mode("sandbox")
 							GLOB.master_mode = "sandbox"
 						else
@@ -200,6 +200,11 @@ SUBSYSTEM_DEF(ticker)
 						else
 							to_chat(world, "<span class='boldnotice'>Notice: The current player count is meets the secret threshold, but the game mode will not be changed because an admin is online.</span>")
 							message_admins("The player count meets the auto secret population threshold, but there are active admins, so the game mode has not changed. If you wish, you may change the game mode to secret.")
+					
+					if(GLOB.master_mode == "sandbox")
+						CONFIG_SET(flag/norespawn, FALSE)
+						world.update_status()
+						message_admins("Respawn has been automatically enabled due to the mode being sandbox.")
 
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does exactly what it says on the tin, when the game mode is sandbox at round start respawn will automatically be enabled.

## Why It's Good For The Game

Admins don't need to manually enable respawn on sandbox rounds.

## Changelog
:cl:
add: Server will automatically enable respawn on sandbox rounds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
